### PR TITLE
oauthトークンを取得する処理を動く形で実装

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
             </ul>
         </div>
     </footer>
-    
+
     <!-- main framework -->
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">

--- a/js/slack-fetch.js
+++ b/js/slack-fetch.js
@@ -1,56 +1,64 @@
-var url = "https://homo-geshuku.github.io/slack-carshare/index"
 var args = getURLparam(location.search.substring(1).split('&'));
 var cookies = getCookieObject(document.cookie);
-var token = "";
+var token = null;
 
-if("token" in cookies){
+if ("token" in cookies) {
     token = cookies["token"];
-}else{
+} else {
+    /* client_idの確認代入処理 「"" < cookiesの中身 < URLパラメータ」 の優先順位で代入,最後に代入した値でcookieを更新 */
     var client_id =
-        "client_id" in args ? args["client_id"]
-        : "client_id" in cookies ? cookies["client_id"]
-        : "";
+        "client_id" in args ? args["client_id"] :
+        "client_id" in cookies ? cookies["client_id"] :
+        "";
     document.cookie = "client_id=" + encodeURIComponent(client_id) + "; max-age=604800";
-    var client_secret = "client_secret" in args ? args["client_secret"]
-        : "client_secret" in cookies ? cookies["client_secret"]
-        : "";
+
+    /* client_secretの確認代入処理 「"" < cookiesの中身 < URLパラメータ」 の優先順位で代入,最後に代入した値でcookieを更新 */
+    var client_secret = "client_secret" in args ? args["client_secret"] :
+        "client_secret" in cookies ? cookies["client_secret"] :
+        "";
     document.cookie = "client_secret=" + encodeURIComponent(client_secret) + "; max-age=604800";
-    var code = "code" in args ? args["code"]
-        : "code" in cookies ? cookies["code"]
-        : getCode(client_id, "channels:history", url);
 
-    token = getToken(client_id, client_secret, code, url);
+    /* codeの確認処理 「"" < cookiesの中身 < URLパラメータ」 の優先順位で代入,最後に代入した値でcookieを更新 */
+    var code = "code" in args ? args["code"] : getCode(client_id, "channels:history");
+
+    /* access_token取得 */
+    getToken(client_id, client_secret, code).then(function (res_token) {
+        token = res_token;
+    }).then(function(){
+        cookies = getCookieObject(document.cookie);
+        document.cookie = "token=" + encodeURIComponent(token) + "; max-age=604800";
+    });
 }
-document.cookie = "token=" + encodeURIComponent(token) + "; max-age=604800";
 
-function getURLparam(pair){
+function getURLparam(pair) {
     var arg = new Object;
-    for(var i = 0; pair[i]; i++) {
+    for (var i = 0; pair[i]; i++) {
         var kv = pair[i].split('=');
         arg[kv[0]] = kv[1];
     }
     return arg;
 }
 
-function getCookieObject(cookie_str){
+function getCookieObject(cookie_str) {
     var cookies = new Object();
-    cookie_str.split(';').forEach(function(value){
+    cookie_str.split(';').forEach(function (value) {
         var key_value = value.split("=");
         cookies[key_value[0]] = key_value[1]
     })
     return cookies;
 }
 
-function getCode(client_id, scope, url){
-   location.href = "https://slack.com/oauth/authorize?client_id=" + client_id + "&scope=" + scope;
+function getCode(client_id, scope) {
+    window.alert("Slack認証画面へ移ります");
+    location.href = "https://slack.com/oauth/authorize?client_id=" + client_id + "&scope=" + scope;
 }
 
-function getToken(client_id, client_secret, code, url){
-    var token = "";
-    fetch("https://slack.com/api/oauth.access?client_id=" + client_id + "&client_secret=" + client_secret + "&code=" + code).then(function(response) {
-        return JSON.parse(response.json()||"null");
-    }).then(function(json) {
-        token = json["access_token"];
+// 返り値 fetchしてきたaccess_tokenを返り値に含むPromiseオブジェクト
+function getToken(client_id, client_secret, code) {
+    return fetch("https://slack.com/api/oauth.access?client_id=" + client_id + "&client_secret=" + client_secret + "&code=" + code).then(function (response) {
+        return response.text();
+    }).then(function (json) {
+        json = JSON.parse(json||"null");
+        return "access_token" in json ? json.access_token : null;
     });
-return token;
 }

--- a/js/slack-fetch.js
+++ b/js/slack-fetch.js
@@ -1,3 +1,4 @@
+var url = "https://homo-geshuku.github.io/slack-carshare/index"
 var args = getURLparam(location.search.substring(1).split('&'));
 var cookies = getCookieObject(document.cookie);
 var token = "";
@@ -9,17 +10,18 @@ if("token" in cookies){
         "client_id" in args ? args["client_id"]
         : "client_id" in cookies ? cookies["client_id"]
         : "";
-    document.cookie = "client_id=" + client_id + "; max-age=604800";
+    document.cookie = "client_id=" + encodeURIComponent(client_id) + "; max-age=604800";
     var client_secret = "client_secret" in args ? args["client_secret"]
         : "client_secret" in cookies ? cookies["client_secret"]
         : "";
-    document.cookie = "client_secret=" + client_secret + "; max-age=604800";
+    document.cookie = "client_secret=" + encodeURIComponent(client_secret) + "; max-age=604800";
     var code = "code" in args ? args["code"]
         : "code" in cookies ? cookies["code"]
-        : getCode(client_id, "channels:history");
-    token = getToken(client_id, client_secret, code);
+        : getCode(client_id, "channels:history", url);
+
+    token = getToken(client_id, client_secret, code, url);
 }
-document.cookie = "token=" + token + "; max-age=604800";
+document.cookie = "token=" + encodeURIComponent(token) + "; max-age=604800";
 
 function getURLparam(pair){
     var arg = new Object;
@@ -39,11 +41,11 @@ function getCookieObject(cookie_str){
     return cookies;
 }
 
-function getCode(client_id, scope){
+function getCode(client_id, scope, url){
    location.href = "https://slack.com/oauth/authorize?client_id=" + client_id + "&scope=" + scope;
 }
 
-function getToken(client_id, client_secret, code){
+function getToken(client_id, client_secret, code, url){
     var token = "";
     fetch("https://slack.com/api/oauth.access?client_id=" + client_id + "&client_secret=" + client_secret + "&code=" + code).then(function(response) {
         return JSON.parse(response.json()||"null");


### PR DESCRIPTION
各種リクエストに必要なキーパラメータをクッキーへ保存し、リダイレクトして戻ってきた後もそれらを保持し、トークンを取得してクッキーで1週間保持できる状態が完動する状態へ実装する